### PR TITLE
Update field names to match content type.

### DIFF
--- a/xmlgenq/tasks/templates/speccoll.tmpl
+++ b/xmlgenq/tasks/templates/speccoll.tmpl
@@ -6,7 +6,7 @@
     {# Title Info #}
 
     <titleInfo>
-      <title>{{ title }}</title>
+      <title>{{ field_title }}</title>
     {% if field_subtitle is defined %}
       <subtitle>{{ field_subtitle }}</subtitle>
     {% endif %}
@@ -16,7 +16,7 @@
        <title>{{ field_uniform }}</title>
     </titleInfo>
     {% endif %}
-    {% if field_alternative is defined %}
+    {% if field_alternate is defined %}
     <titleInfo type ="alternative">
       {% for altitem in field_alternative %}
         <title>{{ altitem }}</title>


### PR DESCRIPTION
* Use `field_title` rather than `title` 
* Fix spelling of `field_alternative`

## Motivation and Context

Drupal field names should probably be canonical so we don't have to do special mappings. Title would be a special case, but we're using entity_autolabel to generate a display title that pulls from field_title, which is a normal Drupal field, so we can just grab that. 

## Testing
Hope!